### PR TITLE
Fix cancel calls referencing global tool objects

### DIFF
--- a/static/js/lines.js
+++ b/static/js/lines.js
@@ -152,16 +152,16 @@ App.modules.lines = (function () {
         if (window.DottedLineTool) window.DottedLineTool.cancel();
         break;
       case "launcher":
-        if (window.LauncherCreateTool) LauncherCreateTool.cancel();
+        if (window.LauncherCreateTool) window.LauncherCreateTool.cancel();
         break;
       case "compactor":
-        if (window.CompactorCreateTool) CompactorCreateTool.cancel();
+        if (window.CompactorCreateTool) window.CompactorCreateTool.cancel();
         break;
       case "gear":
-        if (window.GearCreateTool) GearCreateTool.cancel();
+        if (window.GearCreateTool) window.GearCreateTool.cancel();
         break;
       case "bubble-wand":
-        if (window.BubbleWandCreateTool) BubbleWandCreateTool.cancel();
+        if (window.BubbleWandCreateTool) window.BubbleWandCreateTool.cancel();
         break;
     }
 


### PR DESCRIPTION
## Summary
- fix tool cancellation calls in `lines.js` to use `window.*`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842057e1cb083268911913563f0143d