### PR TITLE
Fix iPad drawing and deletion issues

### DIFF
--- a/static/js/base-drawing-tool.js
+++ b/static/js/base-drawing-tool.js
@@ -77,10 +77,14 @@ class BaseDrawingTool {
 
   // Generic mobile touch handling
   handleTouchEnd(x, y, onEnd, onCancel, cost) {
-    // If there was no drag or the movement is too small, cancel.
+    /* Only the very first drag gesture needs to pass the 25 px check.
+       Subsequent steps (state > 0) may finish exactly where they started. */
+    const mustValidate = this.state === 0;
+
     if (
-      !this._hasMoved ||
-      !BaseDrawingTool.isValidDrag(this._mobileStartPoint, x, y)
+      mustValidate &&
+      (!this._hasMoved ||
+        !BaseDrawingTool.isValidDrag(this._mobileStartPoint, x, y))
     ) {
       if (onCancel) onCancel.call(this);
       BaseDrawingTool.ignoreNextClick = true;

--- a/static/js/base-drawing-tool.js
+++ b/static/js/base-drawing-tool.js
@@ -77,9 +77,9 @@ class BaseDrawingTool {
 
   // Generic mobile touch handling
   handleTouchEnd(x, y, onEnd, onCancel, cost) {
-    /* Only the very first drag gesture needs to pass the 25 px check.
-       Subsequent steps (state > 0) may finish exactly where they started. */
-    const mustValidate = this.state === 0;
+    /* Only the very first drag gesture needs to pass the 25 px check
+       – except for Gears which should always finalise immediately. */
+    const mustValidate = this.state === 0 && this.toolName !== "gear";
 
     if (
       mustValidate &&

--- a/static/js/input-manager.js
+++ b/static/js/input-manager.js
@@ -92,14 +92,24 @@
     }
   });
 
-  document.addEventListener("touchmove", (e) => {
-    if (e.touches.length !== 1) return;
-    const touch = e.touches[0];
-    const tool = getActiveTool();
-    if (tool && typeof tool.onTouchMove === "function") {
-      tool.onTouchMove(touch.pageX, touch.pageY);
-    }
-  });
+  // Touch move – block page scroll while a tool is active (iPad Safari issue)
+  document.addEventListener(
+    "touchmove",
+    (e) => {
+      if (e.touches.length !== 1) return;
+
+      const tool = getActiveTool();
+      if (tool && App.modules.lines.getMode() !== "none") {
+        e.preventDefault(); // stop vertical page scroll
+      }
+
+      const touch = e.touches[0];
+      if (tool && typeof tool.onTouchMove === "function") {
+        tool.onTouchMove(touch.pageX, touch.pageY);
+      }
+    },
+    { passive: false }
+  );
 
   document.addEventListener("touchend", (e) => {
     const touch = e.changedTouches[0];

--- a/static/js/line-interaction.js
+++ b/static/js/line-interaction.js
@@ -171,6 +171,15 @@
   // --- hit-testing helper : returns body (or array) under point -------------
   function getLineAtPoint(x, y) {
     if (!window.BallFall || !window.BallFall.world) return null;
+
+    /* ----- compensate for iOS pinch-zoom -------------------------------- */
+    if (window.visualViewport && window.visualViewport.scale !== 1) {
+      const vv = window.visualViewport;
+      x = x / vv.scale + (vv.offsetLeft || 0);
+      y = y / vv.scale + (vv.offsetTop || 0);
+    }
+    /* -------------------------------------------------------------------- */
+
     const point = { x, y };
     const bodies = Matter.Composite.allBodies(window.BallFall.world);
 


### PR DESCRIPTION
## Summary
- allow subsequent touches to finalize without a drag threshold
- prevent page scrolling during active drawing
- adjust hit-testing for pinch‑zoomed viewports

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_684205f8021c8326aaa8650285010fd9