### PR TITLE
Fix achievement link behavior and init checks

### DIFF
--- a/layouts/partials/ball-machine-ui.html
+++ b/layouts/partials/ball-machine-ui.html
@@ -224,7 +224,7 @@
 <div id="spawner-container">
   <!-- New Coin Info Container (displayed if any recurring revenue exists or simulation has started) -->
   <div id="coin-info" style="display: none">
-    <div id="achievement-link" style="cursor:pointer;" onclick="window.open('/this-website/#achievements','_blank')">
+    <div id="achievement-link" style="cursor:pointer;">
       <img src="{{ "images/achievement-yes.png" | relURL }}" style="width:12px;height:12px;margin-right:2px;" alt="Achievements" />
       <span id="achievement-counter">0/27</span>
     </div>
@@ -370,6 +370,7 @@
 
     (function () {
       const clearBallsBtn = document.getElementById("clearBallsBtn"),
+        achievementLink = document.getElementById("achievement-link"),
         dropRateValue = document.getElementById("bfui-drop-rate-value"),
         dottedBtn = document.getElementById("toggleDotted"),
         straightBtn = document.getElementById("toggleStraight"),
@@ -401,6 +402,19 @@
         e.stopPropagation(); // Prevent click from bubbling up (e.g., to document click listeners)
         window.BallFall.clearBalls();
       });
+
+      if (achievementLink) {
+        achievementLink.addEventListener("click", (e) => {
+          const tool = window.getActiveTool ? window.getActiveTool() : null;
+          if (tool && tool.state && tool.state !== 0) {
+            e.preventDefault();
+            e.stopPropagation();
+            if (typeof tool.cancel === "function") tool.cancel();
+            return;
+          }
+          window.open('/this-website/#achievements', '_blank');
+        });
+      }
 
       // HELP button doesn't need a listener as it's a simple link.
 

--- a/layouts/shortcodes/achievements.html
+++ b/layouts/shortcodes/achievements.html
@@ -27,6 +27,12 @@ document.addEventListener('DOMContentLoaded', function(){
       row.appendChild(document.createTextNode(a.desc));
       container.appendChild(row);
     });
+    if (location.hash && location.hash.includes('achievements')) {
+      var anchor = document.getElementById('achievements');
+      if (anchor) {
+        setTimeout(function(){ anchor.scrollIntoView(); }, 50);
+      }
+    }
   } catch(e){
     console.error('Failed to render achievements', e);
     container.textContent = 'Error loading achievements.';

--- a/static/js/achievements.js
+++ b/static/js/achievements.js
@@ -163,12 +163,34 @@
     if (pages.length == 1 && rps >= 1000000) unlock("one_tab_army");
   }
 
+  function checkSavedCoins() {
+    const coins = App.config && App.config.coins ? App.config.coins : 0;
+    if (coins >= 1) unlock("minimum_viable_product");
+    if (coins >= 1000) unlock("thousandaire");
+    if (coins >= 1000000) unlock("millionaire");
+    if (coins >= 1000000000) unlock("billionaire");
+  }
+
+  function checkSavedRps() {
+    let total = 0;
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k.startsWith("game.") && k.endsWith(".revenue")) {
+        const r = JSON.parse(localStorage.getItem(k));
+        total += Number(r) || 0;
+      }
+    }
+    if (total > 0) checkRps(total);
+  }
+
   function init() {
     updateCounter();
     checkReturn();
     checkPagesThisSession();
     checkPages();
     checkUpgrades();
+    checkSavedCoins();
+    checkSavedRps();
   }
 
   App.Achievements = {


### PR DESCRIPTION
## Summary
- make achievements link open logic script-based
- block navigation if a tool is being drawn
- ensure achievements page scrolls after list render
- grant coin and revenue achievements on initialization

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68474858467883269b46cd7c2e48b06b