### PR TITLE
Fix recurring revenue reset

### DIFF
--- a/static/js/game.js
+++ b/static/js/game.js
@@ -152,6 +152,13 @@
   }
 
   function updateRevenue() {
+    if (!window.App.simulationLoaded) {
+      const thisDisplay = document.getElementById("thispage-revenue-display");
+      if (thisDisplay) thisDisplay.innerHTML = "";
+      App.autoIncomeThisSecond = 0;
+      return;
+    }
+
     // 1) record this second’s auto-clicker income
     const thisRate = App.autoIncomeThisSecond || 0;
 
@@ -171,13 +178,12 @@
     // 4) update the on-page display
     const thisDisplay = document.getElementById("thispage-revenue-display");
     if (thisDisplay) {
-      thisDisplay.innerHTML = window.App.simulationLoaded
-        ? 'This page: <img src="' +
-          coinCostURL +
-          '" alt="Coin" style="width:12px;height:12px;"> ' +
-          App.formatNumber(currentPageRate) +
-          " /s"
-        : "";
+      thisDisplay.innerHTML =
+        'This page: <img src="' +
+        coinCostURL +
+        '" alt="Coin" style="width:12px;height:12px;"> ' +
+        App.formatNumber(currentPageRate) +
+        " /s";
     }
 
     // 5) persist ALWAYS even if auto-clicker’s not active, because now we are checking for if revenue comes from autoclicker balls directly.  The below check that was here before was causing revenue not to be saved after the autoclicker was refunded.


### PR DESCRIPTION
## Summary
- prevent saving revenue when simulation hasn't started

## Testing
- `hugo --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6d9ee60c832695b09e7a84e413c1