### PR TITLE
Add social preview image fallback

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -8,6 +8,7 @@ summaryLength   = 100      # ← add this here
 
 [params]
   description = 'hockenworks is a site for Brian Hockenmaiers personal projects, essays, and a click-to-run Matter.js physics game on each page called The Ball Machine.'
+  banner = '/images/hero-banner-wide.png'
 
 [taxonomies]
 category = "categories"      # For post types like project overviews, project update, essays, thought, etc.

--- a/layouts/partials/paige/metas.html
+++ b/layouts/partials/paige/metas.html
@@ -1,0 +1,50 @@
+{{ $page := . }}
+
+<meta charset="utf-8">
+
+{{ with partial "paige/authors.html" $page }}
+    {{ $authors := slice }}
+
+    {{ range . }}
+        {{ $authors = $authors | append .Title }}
+    {{ end }}
+
+    <meta content="{{ delimit $authors `, ` }}" name="author">
+{{ end }}
+
+{{ with $page.Description }}
+    <meta content="{{ . }}" name="description">
+{{ end }}
+
+{{ if or $page.Keywords $page.Params.tags $page.Params.categories }}
+    <meta content="{{ delimit (sort (union (union $page.Keywords $page.Params.tags) $page.Params.categories)) `, ` }}" name="keywords">
+{{ end }}
+
+<meta content="{{ $page.Param `paige.color` | default `#0d6efd` }}" name="msapplication-TileColor">
+
+{{ if fileExists "assets/browserconfig.xml" }}
+    <meta content="{{ (resources.Get `browserconfig.xml` | resources.ExecuteAsTemplate `browserconfig.xml` .).RelPermalink }}" name="msapplication-config">
+{{ end }}
+
+<meta content="https://github.com/willfaught/paige" name="theme">
+<meta content="{{ $page.Param `paige.color` | default `#0d6efd` }}" name="theme-color">
+<meta content="width=device-width, initial-scale=1" name="viewport">
+
+{{ template "_internal/opengraph.html" $page }}
+{{ template "_internal/twitter_cards.html" $page }}
+
+{{/* Determine social preview image */}}
+{{ $img := $page.Params.featured }}
+{{ if not $img }}
+    {{ $match := findRE `<img[^>]*src=["']([^"']+)["']` $page.Content 1 }}
+    {{ if gt (len $match) 0 }}
+        {{ $img = replaceRE `<img[^>]*src=["']([^"']+)["'].*` `$1` (index $match 0) }}
+    {{ end }}
+{{ end }}
+{{ if not $img }}
+    {{ $img = site.Params.banner }}
+{{ end }}
+{{ with $img }}
+    <meta property="og:image" content="{{ . | absURL }}">
+    <meta name="twitter:image" content="{{ . | absURL }}">
+{{ end }}

--- a/notes/social-previews.md
+++ b/notes/social-previews.md
@@ -1,0 +1,11 @@
+# Social Preview Images
+
+To control the image shown when a page is shared on social platforms, set a `featured` value in the page front matter:
+
+```toml
+featured = "/images/your-image.png"
+```
+
+If no `featured` value is provided, the first image in the body will be used. As a last fallback the site wide banner from `params.banner` in `hugo.toml` is used.
+
+After publishing, verify the metadata using tools like [Facebook Debugger](https://developers.facebook.com/tools/debug/) or [LinkedIn Post Inspector](https://www.linkedin.com/post-inspector/).


### PR DESCRIPTION
## Summary
- add social preview image generation to `metas.html`
- set site-wide default image `params.banner`
- document how to set `featured` and verify previews

## Testing
- `hugo version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850bafc55d88326a462067ad8f3eb8f