### PR TITLE
Enable simple image zoom viewer

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -29,6 +29,8 @@
 
         {{ partial "paige/scripts.html" $page }}
 
+        <script src="{{ "js/image-popup.js" | absURL }}"></script>
+
         {{ if templates.Exists "partials/paige/body-last.html" }}
             {{ partial "paige/body-last.html" $page }}
         {{ end }}

--- a/static/js/image-popup.js
+++ b/static/js/image-popup.js
@@ -1,0 +1,56 @@
+(function () {
+  const overlayId = 'image-zoom-overlay';
+
+  function removeOverlay() {
+    const overlay = document.getElementById(overlayId);
+    if (overlay) {
+      overlay.remove();
+      document.body.style.overflow = '';
+    }
+  }
+
+  document.addEventListener('click', function (e) {
+    const overlay = document.getElementById(overlayId);
+
+    if (overlay) {
+      // If overlay is open, clicking anywhere on it closes it
+      if (e.target === overlay || overlay.contains(e.target)) {
+        removeOverlay();
+      }
+      return;
+    }
+
+    if (window.App && window.App.simulationLoaded) return;
+
+    const img = e.target.closest('img');
+    if (!img) return;
+    if (img.closest('a, button, #ballfall-ui, #spawner-container')) return;
+
+    const ov = document.createElement('div');
+    ov.id = overlayId;
+    ov.style.position = 'fixed';
+    ov.style.top = '0';
+    ov.style.left = '0';
+    ov.style.width = '100%';
+    ov.style.height = '100%';
+    ov.style.background = 'rgba(0,0,0,0.8)';
+    ov.style.backdropFilter = 'blur(5px)';
+    ov.style.display = 'flex';
+    ov.style.alignItems = 'center';
+    ov.style.justifyContent = 'center';
+    ov.style.zIndex = '10000';
+    ov.style.cursor = 'zoom-out';
+
+    const big = document.createElement('img');
+    big.src = img.src;
+    big.style.maxWidth = '90%';
+    big.style.maxHeight = '90%';
+    big.style.objectFit = 'contain';
+    ov.appendChild(big);
+
+    ov.addEventListener('click', removeOverlay);
+
+    document.body.appendChild(ov);
+    document.body.style.overflow = 'hidden';
+  });
+})();


### PR DESCRIPTION
## Summary
- show clicked images in a full screen overlay with blurred background
- load new image-popup script on every page

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a68ccaa48326a3eff23541e1324b