### PR TITLE
Fix render hook quoting

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,0 +1,9 @@
+{{- /* render-image.html */ -}}
+{{- $path := printf "images/%s" (path.Base .Destination) -}}
+{{- with resources.Get $path }}
+  {{- $webp := .Resize "0x webp q85" -}}
+  <picture>
+    <source type="image/webp" srcset="{{ $webp.RelPermalink }}">
+    {{ partial "paige/image" (dict "resource" . "alt" $.Text "loading" "lazy") }}
+  </picture>
+{{- end }}

--- a/notes/site-description.md
+++ b/notes/site-description.md
@@ -9,3 +9,5 @@ On top of the site runs a physics simulation game I call "The Ball Machine." Its
 Ball Machine is only fully loaded when the user clicks the spawner on any page, but can also do some things like keep track of an uptick of coins earned in the background when the game is not loaded. It is the reason for some of how assets are referenced around the site.
 
 This site is deployed via github pages, which contains the content from the /public folder, which I deploy by pushing changes to a special gh-pages branch which is picked up through GH actions. It is served on hockenworks.com via Cloudflare.
+
+All images live under `assets/images` so that Hugo's resource pipeline can process them. A render hook converts each image to WebP at build time and outputs a `<picture>` block with a WebP `<source>` and the original file as a fallback. The hook calls Paige's built-in image partial so images keep their intrinsic width and height.


### PR DESCRIPTION
## Summary
- fix quoting in `render-image.html` for WebP image processing

## Testing
- `hugo --minify --quiet -d public_test`


------
https://chatgpt.com/codex/tasks/task_e_6854d575aba48326ab3e1da7541ef670