### PR TITLE
Add collapsible shortcode with collider rebuild

### DIFF
--- a/layouts/shortcodes/collapsible.html
+++ b/layouts/shortcodes/collapsible.html
@@ -1,0 +1,27 @@
+{{ $id := printf "hw-collapse-%d" now.UnixNano }}
+<details id="{{$id}}" class="hw-collapse">
+  <summary>{{ .Get "title" }}</summary>
+  <div class="hw-collapse-content">
+    {{ .Inner | safeHTML }}
+  </div>
+</details>
+<script>
+(function(){
+  const el = document.getElementById('{{ $id }}');
+  if(!el) return;
+  const rebuild = () => {
+    if(window.App && App.modules && App.modules.text && App.modules.text.rebuild){
+      App.modules.text.rebuild();
+    }
+    if(window.BallFall && window.BallFall.rebuildMediaColliders){
+      window.BallFall.rebuildMediaColliders();
+    }
+  };
+  el.addEventListener('toggle', () => {
+    setTimeout(rebuild, 100);
+  });
+  const obs = new MutationObserver(() => setTimeout(rebuild, 100));
+  obs.observe(el, {childList: true, subtree: true});
+})();
+</script>
+

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -146,3 +146,35 @@ article.paige-latest-item a:hover:not(.nav-link),
 .link-green:hover {
   color: #a8d8c0;
 }
+
+/* Collapsible shortcode styles */
+.hw-collapse {
+  border: 1px solid #444;
+  border-radius: 4px;
+  margin: 1em 0;
+  background: #2a2a2a;
+}
+.hw-collapse summary {
+  cursor: pointer;
+  padding: 0.5em 1em;
+  list-style: none;
+  background: #333;
+  color: #a7bbad;
+  font-weight: bold;
+  position: relative;
+}
+.hw-collapse summary::-webkit-details-marker {
+  display: none;
+}
+.hw-collapse summary::after {
+  content: "\25B8";
+  position: absolute;
+  right: 1em;
+  transition: transform 0.2s;
+}
+.hw-collapse[open] summary::after {
+  transform: rotate(90deg);
+}
+.hw-collapse .hw-collapse-content {
+  padding: 1em;
+}

--- a/static/js/base-simulation.js
+++ b/static/js/base-simulation.js
@@ -137,7 +137,17 @@ App.modules.base = (function () {
       });
     }
 
+    function rebuildMediaColliders() {
+      const world = window.BallFall.world;
+      (window.BallFall.mediaColliders || []).forEach((c) => {
+        Matter.World.remove(world, c);
+      });
+      window.BallFall.mediaColliders = [];
+      addMediaColliders();
+    }
+
     addMediaColliders();
+    window.BallFall.rebuildMediaColliders = rebuildMediaColliders;
 
     // ---- New Media Interaction Update ----
     // For each ball, if it overlaps a media collider, apply high drag and trigger a ripple once.

--- a/static/js/text.js
+++ b/static/js/text.js
@@ -344,5 +344,15 @@ App.modules.text = (function () {
       window.addEventListener("BallFallBaseReady", runTextModule);
     }
   }
-  return { init };
+  function rebuild() {
+    if (!window.BallFall || !window.BallFall.world) return;
+    const world = window.BallFall.world;
+    world.bodies.slice().forEach((body) => {
+      if (body.elRef || body.elRefs) {
+        Matter.World.remove(world, body);
+      }
+    });
+    runTextModule();
+  }
+  return { init, rebuild };
 })();


### PR DESCRIPTION
## Summary
- add Dark-theme collapsible shortcode that rebuilds ball-machine colliders on toggle
- expose collider rebuild helpers in text and base simulation modules
- style collapsible component in custom CSS

## Testing
- `npm test` *(fails: could not read package.json)*
- `hugo` *(fails: template for shortcode "paige/image" not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fa77c6a408326b957025a9dbfb8ea