### PR TITLE
Limit resource use for interactive embeds

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -30,6 +30,7 @@
         {{ partial "paige/scripts.html" $page }}
 
         <script src="{{ "js/image-popup.js" | absURL }}"></script>
+        <script src="{{ "js/embed-manager.js" | absURL }}"></script>
 
         {{ if templates.Exists "partials/paige/body-last.html" }}
             {{ partial "paige/body-last.html" $page }}

--- a/layouts/shortcodes/agent-mode-solar-system-self-contained.html
+++ b/layouts/shortcodes/agent-mode-solar-system-self-contained.html
@@ -22,7 +22,10 @@
 
 <div class="agent-mode-solar-wrapper">
   <iframe
-    src="/html/agent-mode-solar-system-self-contained.html"
+    class="lazy-iframe"
+    data-src="/html/agent-mode-solar-system-self-contained.html"
+    src="about:blank"
+    loading="lazy"
     style="position:absolute; top:0; left:0; width:100%; height:100%; border:1px solid #ccc;"
   ></iframe>
 </div>

--- a/layouts/shortcodes/gpt5-exponential-bounce-self-contained.html
+++ b/layouts/shortcodes/gpt5-exponential-bounce-self-contained.html
@@ -22,7 +22,10 @@
 
 <div class="agent-mode-solar-wrapper">
   <iframe
-    src="/html/exponential_bounce.html"
+    class="lazy-iframe"
+    data-src="/html/exponential_bounce.html"
+    src="about:blank"
+    loading="lazy"
     style="position:absolute; top:0; left:0; width:100%; height:100%; border:1px solid #ccc;"
   ></iframe>
 </div>

--- a/layouts/shortcodes/picross-generator-self-contained.html
+++ b/layouts/shortcodes/picross-generator-self-contained.html
@@ -24,6 +24,11 @@
 
 <div class="picross-wrapper">
   <div class="frame">
-    <iframe src="/html/picross-generator.html"></iframe>
+    <iframe
+      class="lazy-iframe"
+      data-src="/html/picross-generator.html"
+      src="about:blank"
+      loading="lazy"
+    ></iframe>
   </div>
 </div>

--- a/layouts/shortcodes/solar-system-self-contained.html
+++ b/layouts/shortcodes/solar-system-self-contained.html
@@ -1,7 +1,10 @@
 <!-- layouts/shortcodes/solar-system.html -->
 <div style="width:100%; max-width:1000px; margin:1em auto; position:relative; padding-top:70%;">
   <iframe
-    src="/html/solar-system-self-contained.html"
+    class="lazy-iframe"
+    data-src="/html/solar-system-self-contained.html"
+    src="about:blank"
+    loading="lazy"
     style="position:absolute; top:0; left:0; width:100%; height:100%; border:1px solid #ccc;"
   ></iframe>
 </div>

--- a/static/js/embed-manager.js
+++ b/static/js/embed-manager.js
@@ -1,0 +1,72 @@
+// Automatically loads the most visible iframe with class "lazy-iframe"
+// and unloads others to save resources.
+document.addEventListener("DOMContentLoaded", () => {
+  const frames = Array.from(document.querySelectorAll("iframe.lazy-iframe"));
+  if (frames.length === 0) return;
+
+  const placeholder = "/images/embed-placeholder.png";
+
+  const showPlaceholder = (f) => {
+    const p = f.parentElement;
+    p.style.backgroundImage = `url('${placeholder}')`;
+    p.style.backgroundPosition = "center";
+    p.style.backgroundRepeat = "no-repeat";
+    p.style.backgroundSize = "cover";
+    f.style.display = "none";
+  };
+
+  const hidePlaceholder = (f) => {
+    const p = f.parentElement;
+    p.style.backgroundImage = "none";
+    f.style.display = "block";
+  };
+
+  const load = (f) => {
+    if (f.src !== f.dataset.src) f.src = f.dataset.src;
+    hidePlaceholder(f);
+  };
+  const unload = (f) => {
+    if (f.src !== "about:blank") f.src = "about:blank";
+    showPlaceholder(f);
+  };
+
+  frames.forEach((f) => {
+    f.dataset.ratio = "0";
+    unload(f);
+  });
+
+  if (frames.length === 1) {
+    load(frames[0]);
+    return;
+  }
+
+  let active = null;
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        const iframe = entry.target.querySelector("iframe.lazy-iframe");
+        iframe.dataset.ratio = entry.intersectionRatio.toString();
+      });
+      let most = frames[0];
+      for (const f of frames) {
+        if (parseFloat(f.dataset.ratio) > parseFloat(most.dataset.ratio)) {
+          most = f;
+        }
+      }
+      if (most !== active) {
+        frames.forEach((f) => {
+          if (f === most) {
+            load(f);
+          } else {
+            unload(f);
+          }
+        });
+        active = most;
+      }
+    },
+    { threshold: Array.from({ length: 21 }, (_, i) => i / 20) },
+  );
+
+  frames.forEach((f) => observer.observe(f.parentElement));
+});


### PR DESCRIPTION
## Summary
- Only load the interactive embed that is most visible on screen
- Mark solar system, picross, and bounce shortcodes for lazy loading
- Include a script to swap iframe sources based on visibility
- Show a centered wallpaper image when inactive embeds are unloaded
- Observe iframe wrappers so off-screen embeds can activate as they scroll into view

## Testing
- `npx prettier -w static/js/embed-manager.js`
- `hugo` *(fails: template for shortcode "paige/image" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d8bf47c083269972446d4fafdaba