### PR TITLE
Fix mobile scroll blocking logic for ball machine

### DIFF
--- a/static/js/ball-machine-app.js
+++ b/static/js/ball-machine-app.js
@@ -20,8 +20,18 @@ async function requestWakeLock() {
 }
 
 // This is where to keep all of the app's Global variables
+// Device detection shared across modules
+const deviceInfo = {
+  isMobileLike:
+    navigator.userAgentData?.mobile === true ||
+    /Mobi|Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+      navigator.userAgent
+    ) ||
+    (window.innerWidth < 620 && navigator.hardwareConcurrency <= 4),
+};
 
 window.App = {
+  device: deviceInfo,
   config: {
     spawnInterval: 4480, // Default ball spawn interval in ms (auto-clicker rate)
     gravity: 0.75,

--- a/static/js/base-simulation.js
+++ b/static/js/base-simulation.js
@@ -60,12 +60,8 @@ App.modules.base = (function () {
 
     // Run physics substeps.
     // Tune this down for better performance, up for better physics consistency
-    const isMobileLike =
-      navigator.userAgentData?.mobile === true ||
-      /Mobi|Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-        navigator.userAgent
-      ) ||
-      (window.innerWidth < 620 && navigator.hardwareConcurrency <= 4);
+    // Use shared device detection to keep logic consistent across modules
+    const isMobileLike = App.device.isMobileLike;
 
     /* base-simulation.js */
 

--- a/static/js/lines.js
+++ b/static/js/lines.js
@@ -138,8 +138,8 @@ App.modules.lines = (function () {
     },
   };
 
-  const isTouchDevice =
-    "ontouchstart" in window || navigator.maxTouchPoints > 0;
+  // Shared mobile detection (avoids blocking scroll on desktop touch devices)
+  const isMobileLike = App.device.isMobileLike;
 
   function setMode(newMode) {
     // cancel preview of previous tool
@@ -170,7 +170,7 @@ App.modules.lines = (function () {
     mode = newMode;
 
     // for touch, prevent scroll when any tool is active
-    if (isTouchDevice) {
+    if (isMobileLike) {
       document.body.style.overflow = newMode !== "none" ? "hidden" : "";
     }
   }


### PR DESCRIPTION
## Summary
- centralize mobile detection and expose via `App.device`
- ensure scroll blocking for drawing tools only on mobile devices
- reuse shared device detection in base simulation

## Testing
- `npm test` *(fails: Could not read package.json)*
- `hugo` *(fails: template for shortcode "paige/quote" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be1f443848832694d1d507a5a75d73